### PR TITLE
New modern search (#676)

### DIFF
--- a/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
+++ b/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
@@ -107,7 +107,7 @@ namespace EngineLayer.ClassicSearch
                             foreach (ScanWithIndexAndNotchInfo scanWithIndexAndNotchInfo in GetAcceptableScans(correspondingCompactPeptide.MonoisotopicMassIncludingFixedMods, searchMode).ToList())
                             {
                                 double thePrecursorMass = scanWithIndexAndNotchInfo.theScan.PrecursorMass;
-                                var score = CalculateClassicScore(scanWithIndexAndNotchInfo.theScan.TheScan, commonParameters.ProductMassTolerance, productMasses, thePrecursorMass, dissociationTypes, addCompIons);
+                                var score = CalculatePeptideScore(scanWithIndexAndNotchInfo.theScan.TheScan, commonParameters.ProductMassTolerance, productMasses, thePrecursorMass, dissociationTypes, addCompIons);
 
                                 if (score > commonParameters.ScoreCutoff)
                                 {

--- a/EngineLayer/CommonParameters.cs
+++ b/EngineLayer/CommonParameters.cs
@@ -28,7 +28,11 @@ namespace EngineLayer
             ListOfModsLocalize = null;
 
             ConserveMemory = true;
-            MaxDegreeOfParallelism = 1;
+
+            MaxParallelFilesToAnalyze = 1;
+
+            MaxThreadsToUsePerFile = Environment.ProcessorCount > 1 ? Environment.ProcessorCount - 1 : 1;
+
             ScoreCutoff = 5;
 
             // Deconvolution stuff
@@ -50,7 +54,8 @@ namespace EngineLayer
 
         #region Public Properties
 
-        public int? MaxDegreeOfParallelism { get; set; }
+        public int? MaxParallelFilesToAnalyze { get; set; }
+        public int MaxThreadsToUsePerFile { get; set; }
         public bool LocalizeAll { get; set; }
         public List<Tuple<string, string>> ListOfModsFixed { get; set; }
         public List<Tuple<string, string>> ListOfModsVariable { get; set; }

--- a/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine2.cs
+++ b/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine2.cs
@@ -378,7 +378,7 @@ namespace EngineLayer.CrosslinkSearch
 
                             foreach (ScanWithIndexAndNotchInfo scanWithIndexAndNotchInfo in GetAcceptableScans(BetaPeptidePrecusor, yyy.MonoisotopicMass, XLBetaSearchMode, selectedScan).ToList())
                             {
-                                var score = CalculateClassicScore(scanWithIndexAndNotchInfo.theScan.TheScan, CommonParameters.ProductMassTolerance, productMasses, yyy.MonoisotopicMass, new List<DissociationType>(), false);
+                                var score = CalculatePeptideScore(scanWithIndexAndNotchInfo.theScan.TheScan, CommonParameters.ProductMassTolerance, productMasses, yyy.MonoisotopicMass, new List<DissociationType>(), false);
 
                                 if (score > 1 && PsmCross.xlPosCal(correspondingCompactPeptide, crosslinker).Count != 0)
                                 {

--- a/EngineLayer/Indexing/IndexingResults.cs
+++ b/EngineLayer/Indexing/IndexingResults.cs
@@ -7,17 +7,17 @@ namespace EngineLayer.Indexing
     {
         #region Public Constructors
 
-        public IndexingResults(List<CompactPeptide> peptideIndex, Dictionary<float, List<int>> fragmentIndexDict, IndexingEngine indexParams) : base(indexParams)
+        public IndexingResults(List<CompactPeptide> peptideIndex, List<int>[] fragmentIndex, IndexingEngine indexParams) : base(indexParams)
         {
             this.PeptideIndex = peptideIndex;
-            this.FragmentIndexDict = fragmentIndexDict;
+            this.FragmentIndex = fragmentIndex;
         }
 
         #endregion Public Constructors
 
         #region Public Properties
 
-        public Dictionary<float, List<int>> FragmentIndexDict { get; private set; }
+        public List<int>[] FragmentIndex { get; private set; }
         public List<CompactPeptide> PeptideIndex { get; private set; }
 
         #endregion Public Properties
@@ -28,7 +28,7 @@ namespace EngineLayer.Indexing
         {
             var sb = new StringBuilder();
             sb.AppendLine(base.ToString());
-            sb.AppendLine("\t\tfragmentIndexDict.Count: " + FragmentIndexDict.Count);
+            sb.AppendLine("\t\tfragmentIndexDict.Count: " + FragmentIndex.Length);
             sb.AppendLine("\t\tpeptideIndex.Count: " + PeptideIndex.Count);
             return sb.ToString();
         }

--- a/EngineLayer/Localization/LocalizationEngine.cs
+++ b/EngineLayer/Localization/LocalizationEngine.cs
@@ -78,7 +78,7 @@ namespace EngineLayer
 
                     var gg = localizedPeptide.CompactPeptide(terminusType).ProductMassesMightHaveDuplicatesAndNaNs(lp);
                     Array.Sort(gg);
-                    var score = CalculateClassicScore(theScan, fragmentTolerance, gg, thePrecursorMass, dissociationTypes, addCompIons);
+                    var score = CalculatePeptideScore(theScan, fragmentTolerance, gg, thePrecursorMass, dissociationTypes, addCompIons);
                     localizedScores.Add(score);
                 }
 

--- a/EngineLayer/MetaMorpheusEngine.cs
+++ b/EngineLayer/MetaMorpheusEngine.cs
@@ -202,7 +202,7 @@ namespace EngineLayer
             }
         }
 
-        public static double CalculateClassicScore(IMsDataScan<IMzSpectrum<IMzPeak>> thisScan, Tolerance productMassTolerance, double[] sortedTheoreticalProductMassesForThisPeptide, double precursorMass, List<DissociationType> dissociationTypes, bool addCompIons)
+        public static double CalculatePeptideScore(IMsDataScan<IMzSpectrum<IMzPeak>> thisScan, Tolerance productMassTolerance, double[] sortedTheoreticalProductMassesForThisPeptide, double precursorMass, List<DissociationType> dissociationTypes, bool addCompIons)
         {
             var TotalProductsHere = sortedTheoreticalProductMassesForThisPeptide.Length;
             if (TotalProductsHere == 0)

--- a/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -20,7 +20,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
 
         #region Public Constructors
 
-        public NonSpecificEnzymeSearchEngine(Psm[] globalPsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<CompactPeptide> peptideIndex, float[] keys, List<int>[] fragmentIndex, List<ProductType> lp, int currentPartition, CommonParameters CommonParameters, bool addCompIons, MassDiffAcceptor massDiffAcceptors, List<string> nestedIds) : base(globalPsms, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, lp, currentPartition, CommonParameters, addCompIons, massDiffAcceptors, nestedIds)
+        public NonSpecificEnzymeSearchEngine(Psm[] globalPsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<CompactPeptide> peptideIndex, List<int>[] fragmentIndex, List<ProductType> lp, int currentPartition, CommonParameters CommonParameters, bool addCompIons, MassDiffAcceptor massDiffAcceptors, List<string> nestedIds) : base(globalPsms, listOfSortedms2Scans, peptideIndex, fragmentIndex, lp, currentPartition, CommonParameters, addCompIons, massDiffAcceptors, nestedIds)
         {
         }
 
@@ -30,123 +30,80 @@ namespace EngineLayer.NonSpecificEnzymeSearch
 
         protected override MetaMorpheusEngineResults RunSpecific()
         {
-            Status("In nonspecific search engine..." + currentPartition + "/" + CommonParameters.TotalPartitions);
+            double progress = 0;
+            int oldPercentProgress = 0;
+            ReportProgress(new ProgressEventArgs(oldPercentProgress, "Performing nonspecific search... " + currentPartition + "/" + CommonParameters.TotalPartitions, nestedIds));
             TerminusType terminusType = ProductTypeMethod.IdentifyTerminusType(lp);
-            var listOfSortedms2ScansLength = listOfSortedms2Scans.Length;
 
-            var outputObject = new object();
-            int scansSeen = 0;
-            int old_progress = 0;
-            var peptideIndexCount = peptideIndex.Count;
-            Parallel.ForEach(Partitioner.Create(0, listOfSortedms2ScansLength), fff =>
+            int intScoreCutoff = (int)CommonParameters.ScoreCutoff;
+            byte byteScoreCutoff = Convert.ToByte(intScoreCutoff);
+
+            Parallel.ForEach(Partitioner.Create(0, listOfSortedms2Scans.Length), new ParallelOptions { MaxDegreeOfParallelism = CommonParameters.MaxThreadsToUsePerFile }, range =>
             {
-                List<CompactPeptideBase> bestPeptides;
-                double bestScores;
-                List<int> bestNotches;
-                double[] fullPeptideScores = new double[peptideIndexCount];
-                for (int i = fff.Item1; i < fff.Item2; i++)
+                byte[] scoringTable = new byte[peptideIndex.Count];
+                HashSet<int> idsOfPeptidesPossiblyObserved = new HashSet<int>();
+
+                for (int i = range.Item1; i < range.Item2; i++)
                 {
-                    var thisScan = listOfSortedms2Scans[i];
-                    var thisScanprecursorMass = thisScan.PrecursorMass;
-                    Array.Clear(fullPeptideScores, 0, peptideIndexCount);
-                    double thePrecursorMass = thisScan.PrecursorMass;
-                    CalculatePeptideScores(thisScan.TheScan, fullPeptideScores, thePrecursorMass);
+                    // empty the scoring table to score the new scan (conserves memory compared to allocating a new array)
+                    Array.Clear(scoringTable, 0, scoringTable.Length);
+                    idsOfPeptidesPossiblyObserved.Clear();
+                    var scan = listOfSortedms2Scans[i];
 
-                    bestPeptides = null;
-                    bestScores = 0;
-                    bestNotches = null;
+                    // filter ms2 fragment peaks by intensity
+                    int numFragmentsToUse = 0;
+                    if (CommonParameters.TopNpeaks != null)
+                        numFragmentsToUse = (int)CommonParameters.TopNpeaks;
+                    else
+                        numFragmentsToUse = scan.NumPeaks;
 
-                    for (int possibleWinningPeptideIndex = 0; possibleWinningPeptideIndex < fullPeptideScores.Length; possibleWinningPeptideIndex++)
-                    {
-                        var consideredScore = fullPeptideScores[possibleWinningPeptideIndex];
-                        if (consideredScore > CommonParameters.ScoreCutoff) //intentionally high. 99.9% of 4-mers are present in a given UniProt database. This saves considerable time
+                    //get bins to add points to
+                    List<int> allBinsToSearch = GetBinsToSearch(scan);
+
+                    for (int j = 0; j < allBinsToSearch.Count; j++)
+                        foreach (int id in fragmentIndex[allBinsToSearch[j]])
                         {
-                            CompactPeptide candidatePeptide = peptideIndex[possibleWinningPeptideIndex];
-                            // Check if makes sense to add due to peptidescore!
-                            var searchMode = massDiffAcceptors;
-                            double currentBestScore = bestScores;
-                            if (currentBestScore > 1)
+                            scoringTable[id]++;
+                            if (scoringTable[id] == byteScoreCutoff)
+                                idsOfPeptidesPossiblyObserved.Add(id);
+                        }
+
+                    // done with initial scoring; refine scores and create PSMs
+                    if (idsOfPeptidesPossiblyObserved.Any())
+                    {
+                        int maxInitialScore = idsOfPeptidesPossiblyObserved.Max(id => scoringTable[id]) + 1;
+                        while (maxInitialScore != intScoreCutoff)
+                        {
+                            maxInitialScore--;
+                            foreach (var id in idsOfPeptidesPossiblyObserved.Where(id => scoringTable[id] == maxInitialScore))
                             {
-                                // Existed! Need to compare with old match
-                                if ((Math.Abs(currentBestScore - consideredScore) < 1e-9) && (CommonParameters.ReportAllAmbiguity || bestPeptides != null))
+                                var candidatePeptide = peptideIndex[id];
+                                double[] fragmentMasses = candidatePeptide.ProductMassesMightHaveDuplicatesAndNaNs(lp).Distinct().Where(p => !Double.IsNaN(p)).OrderBy(p => p).ToArray();
+                                double peptideScore = CalculatePeptideScore(scan.TheScan, CommonParameters.ProductMassTolerance, fragmentMasses, scan.PrecursorMass, dissociationTypes, addCompIons);
+                                Tuple<int, double> notchAndPrecursor = Accepts(scan.PrecursorMass, candidatePeptide, terminusType, massDiffAcceptor);
+                                if (notchAndPrecursor.Item1 >= 0)
                                 {
-                                    // Score is same, need to see if accepts and if prefer the new one
-                                    double precursorMass = Accepts(thisScanprecursorMass, candidatePeptide, terminusType, searchMode);
-                                    if (precursorMass > 1)
-                                    {
-                                        CompactPeptideWithModifiedMass cp = new CompactPeptideWithModifiedMass(candidatePeptide, precursorMass);
-                                        cp.SwapMonoisotopicMassWithModifiedMass();
-                                        if (bestPeptides == null) //have to check, because current best score may have been found in a previous partition
-                                        {
-                                            bestPeptides = new List<CompactPeptideBase> { cp };
-                                            bestScores = consideredScore;
-                                            bestNotches = new List<int> { 0 };
-                                        }
-                                        else if (!bestPeptides.Contains(cp) && (globalPsms[i] == null || !globalPsms[i].CompactPeptidesContainsKey(cp)))
-                                        {
-                                            bestPeptides.Add(cp);
-                                            bestNotches.Add(0);
-                                        }
-                                    }
-                                }
-                                else if (currentBestScore < consideredScore)
-                                {
-                                    // Score is better, only make sure it is acceptable
-                                    double precursorMass = Accepts(thisScanprecursorMass, candidatePeptide, terminusType, searchMode);
-                                    if (precursorMass > 1)
-                                    {
-                                        CompactPeptideWithModifiedMass cp = new CompactPeptideWithModifiedMass(candidatePeptide, precursorMass);
-                                        cp.SwapMonoisotopicMassWithModifiedMass();
-                                        bestPeptides = new List<CompactPeptideBase> { cp };
-                                        bestScores = consideredScore;
-                                        bestNotches = new List<int> { 0 };
-                                        currentBestScore = consideredScore;
-                                    }
+                                    CompactPeptideWithModifiedMass cp = new CompactPeptideWithModifiedMass(candidatePeptide, notchAndPrecursor.Item2);
+
+                                    if (globalPsms[i] == null)
+                                        globalPsms[i] = new Psm(cp, notchAndPrecursor.Item1, peptideScore, i, scan);
+                                    else
+                                        globalPsms[i].AddOrReplace(cp, peptideScore, notchAndPrecursor.Item1, CommonParameters.ReportAllAmbiguity);
                                 }
                             }
-                            // Did not exist! Only make sure that it is acceptable
-                            else
-                            {
-                                double precursorMass = Accepts(thisScanprecursorMass, candidatePeptide, terminusType, searchMode);
-                                if (precursorMass > 1)
-                                {
-                                    CompactPeptideWithModifiedMass cp = new CompactPeptideWithModifiedMass(candidatePeptide, precursorMass);
-                                    cp.SwapMonoisotopicMassWithModifiedMass();
-                                    bestPeptides = new List<CompactPeptideBase> { cp };
-                                    bestScores = consideredScore;
-                                    bestNotches = new List<int> { 0 };
-                                    currentBestScore = consideredScore;
-                                }
-                            }
+                            if (globalPsms[i] != null)
+                                break;
                         }
                     }
-                    if (bestPeptides != null)
+
+                    // report search progress
+                    progress++;
+                    var percentProgress = (int)((progress / listOfSortedms2Scans.Length) * 100);
+
+                    if (percentProgress > oldPercentProgress)
                     {
-                        foreach (CompactPeptideBase cpb in bestPeptides)
-                            (cpb as CompactPeptideWithModifiedMass).SwapMonoisotopicMassWithModifiedMass();
-
-                        int startIndex = 0;
-
-                        if (globalPsms[i] == null)
-                        {
-                            globalPsms[i] = new Psm(bestPeptides[0], bestNotches[0], bestScores, i, thisScan, CommonParameters.ExcelCompatible);
-                            startIndex = 1;
-                        }
-
-                        for (int k = startIndex; k < bestPeptides.Count; k++)
-                        {
-                            globalPsms[i].AddOrReplace(bestPeptides[k], bestScores, bestNotches[k], CommonParameters.ReportAllAmbiguity);
-                        }
-                    }
-                }
-                lock (outputObject)
-                {
-                    scansSeen += fff.Item2 - fff.Item1;
-                    var new_progress = (int)((double)scansSeen / (listOfSortedms2ScansLength) * 100);
-                    if (new_progress > old_progress)
-                    {
-                        ReportProgress(new ProgressEventArgs(new_progress, "In nonspecific search loop " + currentPartition + "/" + CommonParameters.TotalPartitions, nestedIds));
-                        old_progress = new_progress;
+                        oldPercentProgress = percentProgress;
+                        ReportProgress(new ProgressEventArgs(percentProgress, "Performing nonspecific search... " + currentPartition + "/" + CommonParameters.TotalPartitions, nestedIds));
                     }
                 }
             });
@@ -157,7 +114,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
 
         #region Private Methods
 
-        private double Accepts(double scanPrecursorMass, CompactPeptide peptide, TerminusType terminusType, MassDiffAcceptor searchMode)
+        private Tuple<int, double> Accepts(double scanPrecursorMass, CompactPeptide peptide, TerminusType terminusType, MassDiffAcceptor searchMode)
         {
             //all masses in N and CTerminalMasses are b-ion masses, which are one water away from a full peptide
             int localminPeptideLength = CommonParameters.DigestionParams.MinPeptideLength ?? 0;
@@ -166,9 +123,10 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                 for (int i = localminPeptideLength; i < peptide.NTerminalMasses.Count(); i++)
                 {
                     double theoMass = peptide.NTerminalMasses[i] + waterMonoisotopicMass;
-                    if (searchMode.Accepts(scanPrecursorMass, theoMass) >= 0)
+                    int notch = searchMode.Accepts(scanPrecursorMass, theoMass);
+                    if (notch >= 0)
                     {
-                        return theoMass;
+                        return new Tuple<int, double>(notch, theoMass);
                     }
                     else if (theoMass > scanPrecursorMass)
                     {
@@ -179,9 +137,10 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                 if (peptide.NTerminalMasses.Count() > localminPeptideLength)
                 {
                     double totalMass = peptide.MonoisotopicMassIncludingFixedMods;// + Constants.protonMass;
-                    if (searchMode.Accepts(scanPrecursorMass, totalMass) >= 0)
+                    int notch = searchMode.Accepts(scanPrecursorMass, totalMass);
+                    if (notch >= 0)
                     {
-                        return totalMass;
+                        return new Tuple<int, double>(notch, totalMass);
                     }
                 }
             }
@@ -190,9 +149,10 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                 for (int i = localminPeptideLength; i < peptide.CTerminalMasses.Count(); i++)
                 {
                     double theoMass = peptide.CTerminalMasses[i] + waterMonoisotopicMass;
-                    if (searchMode.Accepts(scanPrecursorMass, theoMass) >= 0)
+                    int notch = searchMode.Accepts(scanPrecursorMass, theoMass);
+                    if (notch >= 0)
                     {
-                        return theoMass;
+                        return new Tuple<int, double>(notch, theoMass);
                     }
                     else if (theoMass > scanPrecursorMass)
                     {
@@ -203,13 +163,14 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                 if (peptide.CTerminalMasses.Count() > localminPeptideLength)
                 {
                     double totalMass = peptide.MonoisotopicMassIncludingFixedMods;// + Constants.protonMass;
-                    if (searchMode.Accepts(scanPrecursorMass, totalMass) >= 0)
+                    int notch = searchMode.Accepts(scanPrecursorMass, totalMass);
+                    if (notch >= 0)
                     {
-                        return totalMass;
+                        return new Tuple<int, double>(notch, totalMass);
                     }
                 }
             }
-            return 0;
+            return new Tuple<int, double>(-1, -1);
         }
 
         #endregion Private Methods

--- a/EngineLayer/PrecursorSearchModes/LowTheoreticalDiffAcceptor.cs
+++ b/EngineLayer/PrecursorSearchModes/LowTheoreticalDiffAcceptor.cs
@@ -4,11 +4,11 @@ using System.Collections.Generic;
 
 namespace EngineLayer
 {
-    public class OpenSearchMode : MassDiffAcceptor
+    public class OpenLowTheoSearchMode : MassDiffAcceptor
     {
         #region Public Constructors
 
-        public OpenSearchMode() : base("OpenSearch")
+        public OpenLowTheoSearchMode() : base("OpenLow")
         {
         }
 
@@ -18,22 +18,22 @@ namespace EngineLayer
 
         public override int Accepts(double scanPrecursorMass, double peptideMass)
         {
-            return 0;
+            return scanPrecursorMass > peptideMass - 1 ? 0 : -1;
         }
 
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervals(double peptideMonoisotopicMass)
         {
-            yield return new AllowedIntervalWithNotch(new DoubleRange(Double.NegativeInfinity, Double.PositiveInfinity), 0);
+            yield return new AllowedIntervalWithNotch(new DoubleRange(Double.NegativeInfinity, peptideMonoisotopicMass + 1), 0);
         }
 
         public override string ToProseString()
         {
-            return ("unbounded");
+            return ("unboundedHigh");
         }
 
         public override string ToString()
         {
-            return FileNameAddition + " OpenSearch";
+            return FileNameAddition + " OpenHighSearch";
         }
 
         #endregion Public Methods

--- a/EngineLayer/Proteomics/CompactPeptideBase.cs
+++ b/EngineLayer/Proteomics/CompactPeptideBase.cs
@@ -54,7 +54,7 @@ namespace EngineLayer
                 throw new NotImplementedException();
             if (containsBnoB1)
                 massLen += NTerminalMasses.Length - 1;
-            if (containsB)
+            else if (containsB)
                 massLen += NTerminalMasses.Length;
             if (containsC)
                 massLen += NTerminalMasses.Length;
@@ -72,12 +72,7 @@ namespace EngineLayer
                 for (int j = 0; j < NTerminalMasses.Length; j++)
                 {
                     var hm = NTerminalMasses[j];
-                    if (containsBnoB1 && j > 0)
-                    {
-                        massesToReturn[i] = hm;
-                        i++;
-                    }
-                    if (containsB)
+                    if (containsB || (containsBnoB1 && j > 0))
                     {
                         massesToReturn[i] = hm;
                         i++;
@@ -89,9 +84,8 @@ namespace EngineLayer
                     }
                 }
             if (CTerminalMasses != null)
-                for (int j = 0; j < CTerminalMasses.Length; j++)
+                foreach (double hm in CTerminalMasses)
                 {
-                    var hm = CTerminalMasses[j];
                     if (containsY)
                     {
                         massesToReturn[i] = hm + waterMonoisotopicMass;

--- a/GUI/CalibrateTaskWindow.xaml.cs
+++ b/GUI/CalibrateTaskWindow.xaml.cs
@@ -73,7 +73,7 @@ namespace MetaMorpheusGUI
 
             bCheckBox.IsChecked = task.CommonParameters.BIons;
             yCheckBox.IsChecked = task.CommonParameters.YIons;
-            maxDegreesOfParallelism.Text = task.CommonParameters.MaxDegreeOfParallelism.ToString();
+            maxDegreesOfParallelism.Text = task.CommonParameters.MaxParallelFilesToAnalyze.ToString();
             zdotCheckBox.IsChecked = task.CommonParameters.ZdotIons;
             cCheckBox.IsChecked = task.CommonParameters.CIons;
 
@@ -252,7 +252,7 @@ namespace MetaMorpheusGUI
                 TheTask.CommonParameters.PrecursorMassTolerance = new PpmTolerance(double.Parse(precursorMassToleranceTextBox.Text, CultureInfo.InvariantCulture));
 
             if (int.TryParse(maxDegreesOfParallelism.Text, out int jsakdf))
-                TheTask.CommonParameters.MaxDegreeOfParallelism = jsakdf;
+                TheTask.CommonParameters.MaxParallelFilesToAnalyze = jsakdf;
 
             DialogResult = true;
         }

--- a/GUI/GPTMDTaskWindow.xaml.cs
+++ b/GUI/GPTMDTaskWindow.xaml.cs
@@ -81,7 +81,7 @@ namespace MetaMorpheusGUI
             precursorMassToleranceTextBox.Text = task.CommonParameters.PrecursorMassTolerance.Value.ToString(CultureInfo.InvariantCulture);
             precursorMassToleranceComboBox.SelectedIndex = task.CommonParameters.PrecursorMassTolerance is AbsoluteTolerance ? 0 : 1;
 
-            maxDegreesOfParallelism.Text = task.CommonParameters.MaxDegreeOfParallelism.ToString();
+            maxDegreesOfParallelism.Text = task.CommonParameters.MaxParallelFilesToAnalyze.ToString();
             bCheckBox.IsChecked = task.CommonParameters.BIons;
             yCheckBox.IsChecked = task.CommonParameters.YIons;
             cCheckBox.IsChecked = task.CommonParameters.CIons;
@@ -293,7 +293,7 @@ namespace MetaMorpheusGUI
                 TheTask.GptmdParameters.ListOfModsGptmd.AddRange(heh.Children.Where(b => b.Use).Select(b => new Tuple<string, string>(b.Parent.DisplayName, b.DisplayName)));
 
             if (int.TryParse(maxDegreesOfParallelism.Text, out int jsakdf))
-                TheTask.CommonParameters.MaxDegreeOfParallelism = jsakdf;
+                TheTask.CommonParameters.MaxParallelFilesToAnalyze = jsakdf;
 
             DialogResult = true;
         }

--- a/GUI/SearchTaskWindow.xaml
+++ b/GUI/SearchTaskWindow.xaml
@@ -183,6 +183,10 @@
                                         <StackPanel Orientation="Horizontal" Margin="5">
                                             <CheckBox x:Name="addCompIonCheckBox" Content="Generate Complementary Ions" />
                                         </StackPanel>
+                                        <StackPanel Orientation="Horizontal" Margin="5">
+                                            <Label x:Name="maxFragmentSize" Content="Max Fragment Mass (Da)" />
+                                            <TextBox x:Name="txtMaxFragmentSize" PreviewTextInput="PreviewIfInt" Width="45" IsEnabled="{Binding IsChecked, ElementName=modernSearchRadioButton}" />
+                                        </StackPanel>
                                     </StackPanel>
                                     <StackPanel Grid.Column="1">
                                         <StackPanel Orientation="Horizontal" Margin="5">

--- a/GUI/SearchTaskWindow.xaml.cs
+++ b/GUI/SearchTaskWindow.xaml.cs
@@ -153,7 +153,7 @@ namespace MetaMorpheusGUI
             classicSearchRadioButton.IsChecked = task.SearchParameters.SearchType == SearchType.Classic;
             modernSearchRadioButton.IsChecked = task.SearchParameters.SearchType == SearchType.Modern;
             nonSpecificSearchRadioButton.IsChecked = task.SearchParameters.SearchType == SearchType.NonSpecific;
-
+            txtMaxFragmentSize.Text = task.SearchParameters.MaxFragmentSize.ToString(CultureInfo.InvariantCulture);
             checkBoxParsimony.IsChecked = task.SearchParameters.DoParsimony;
             checkBoxNoOneHitWonders.IsChecked = task.SearchParameters.NoOneHitWonders;
             checkBoxQuantification.IsChecked = task.SearchParameters.DoQuantification;
@@ -185,7 +185,7 @@ namespace MetaMorpheusGUI
             numberOfDatabaseSearchesTextBox.Text = task.CommonParameters.TotalPartitions.ToString(CultureInfo.InvariantCulture);
             deconvolutePrecursors.IsChecked = task.CommonParameters.DoPrecursorDeconvolution;
             useProvidedPrecursor.IsChecked = task.CommonParameters.UseProvidedPrecursorInfo;
-            maxDegreesOfParallelism.Text = task.CommonParameters.MaxDegreeOfParallelism.ToString();
+            maxDegreesOfParallelism.Text = task.CommonParameters.MaxParallelFilesToAnalyze.ToString();
             disposeOfFilesWhenDone.IsChecked = task.SearchParameters.DisposeOfFileWhenDone;
             allAmbiguity.IsChecked = task.CommonParameters.ReportAllAmbiguity;
             excelCompatible.IsChecked = task.CommonParameters.ExcelCompatible;
@@ -341,9 +341,9 @@ namespace MetaMorpheusGUI
                 MessageBox.Show("The product mass tolerance contains unrecognized characters. \n You entered " + '"' + productMassToleranceTextBox.Text + '"' + "\n Please enter a positive number.");
                 return;
             }
-            if (!double.TryParse(minScoreAllowed.Text, out double msa) || msa < 0)
+            if (!double.TryParse(minScoreAllowed.Text, out double msa) || msa < 1)
             {
-                MessageBox.Show("The minimum score allowed contains unrecognized characters. \n You entered " + '"' + minScoreAllowed.Text + '"' + "\n Please enter a positive number.");
+                MessageBox.Show("The minimum score allowed contains unrecognized characters. \n You entered " + '"' + minScoreAllowed.Text + '"' + "\n Please enter a positive, non-zero number.");
                 return;
             }
 
@@ -404,6 +404,7 @@ namespace MetaMorpheusGUI
             else
                 TheTask.CommonParameters.PrecursorMassTolerance = new PpmTolerance(double.Parse(precursorMassToleranceTextBox.Text, CultureInfo.InvariantCulture));
 
+            TheTask.SearchParameters.MaxFragmentSize = Double.Parse(txtMaxFragmentSize.Text, CultureInfo.InvariantCulture);
             TheTask.SearchParameters.AddCompIons = addCompIonCheckBox.IsChecked.Value;
             TheTask.CommonParameters.BIons = bCheckBox.IsChecked.Value;
             TheTask.CommonParameters.YIons = yCheckBox.IsChecked.Value;
@@ -467,7 +468,7 @@ namespace MetaMorpheusGUI
             TheTask.SearchParameters.WritePrunedDatabase = writePrunedDatabaseCheckBox.IsChecked.Value;
             TheTask.SearchParameters.KeepAllUniprotMods = keepAllUniprotModsCheckBox.IsChecked.Value;
             if (int.TryParse(maxDegreesOfParallelism.Text, out int jsakdf))
-                TheTask.CommonParameters.MaxDegreeOfParallelism = jsakdf;
+                TheTask.CommonParameters.MaxParallelFilesToAnalyze = jsakdf;
 
             #endregion Save Parameters
 

--- a/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -126,8 +126,8 @@ namespace TaskLayer
 
             object lock1 = new object();
             ParallelOptions parallelOptions = new ParallelOptions();
-            if (CommonParameters.MaxDegreeOfParallelism.HasValue)
-                parallelOptions.MaxDegreeOfParallelism = CommonParameters.MaxDegreeOfParallelism.Value;
+            if (CommonParameters.MaxParallelFilesToAnalyze.HasValue)
+                parallelOptions.MaxDegreeOfParallelism = CommonParameters.MaxParallelFilesToAnalyze.Value;
             Status("Calibrating...", new List<string> { taskId });
 
             Parallel.For(0, currentRawFileList.Count, parallelOptions, spectraFileIndex =>

--- a/TaskLayer/GPTMDTask/GPTMDTask.cs
+++ b/TaskLayer/GPTMDTask/GPTMDTask.cs
@@ -118,8 +118,8 @@ namespace TaskLayer
             object lock1 = new object();
             object lock2 = new object();
             ParallelOptions parallelOptions = new ParallelOptions();
-            if (CommonParameters.MaxDegreeOfParallelism.HasValue)
-                parallelOptions.MaxDegreeOfParallelism = CommonParameters.MaxDegreeOfParallelism.Value;
+            if (CommonParameters.MaxParallelFilesToAnalyze.HasValue)
+                parallelOptions.MaxDegreeOfParallelism = CommonParameters.MaxParallelFilesToAnalyze.Value;
             Parallel.For(0, currentRawFileList.Count, parallelOptions, spectraFileIndex =>
             {
                 var origDataFile = currentRawFileList[spectraFileIndex];

--- a/TaskLayer/MetaMorpheusTask.cs
+++ b/TaskLayer/MetaMorpheusTask.cs
@@ -32,7 +32,6 @@ namespace TaskLayer
         public static readonly TomlSettings tomlConfig = TomlSettings.Create(cfg => cfg
                         .ConfigureType<Tolerance>(type => type
                             .WithConversionFor<TomlString>(convert => convert
-
                                 .FromToml(tmlString => Tolerance.ParseToleranceString(tmlString.Value))))
                         .ConfigureType<PpmTolerance>(type => type
                             .WithConversionFor<TomlString>(convert => convert

--- a/TaskLayer/SearchTask/SearchTask.cs
+++ b/TaskLayer/SearchTask/SearchTask.cs
@@ -1,4 +1,4 @@
-using Chemistry;
+﻿using Chemistry;
 using EngineLayer;
 using EngineLayer.Analysis;
 using EngineLayer.ClassicSearch;
@@ -772,8 +772,8 @@ namespace TaskLayer
             proseCreatedWhileRunning.Append("report all ambiguity = " + CommonParameters.ReportAllAmbiguity + "; ");
 
             ParallelOptions parallelOptions = new ParallelOptions();
-            if (CommonParameters.MaxDegreeOfParallelism.HasValue)
-                parallelOptions.MaxDegreeOfParallelism = CommonParameters.MaxDegreeOfParallelism.Value;
+            if (CommonParameters.MaxParallelFilesToAnalyze.HasValue)
+                parallelOptions.MaxDegreeOfParallelism = CommonParameters.MaxParallelFilesToAnalyze.Value;
             MyFileManager myFileManager = new MyFileManager(SearchParameters.DisposeOfFileWhenDone);
 
             HashSet<DigestionParams> ListOfDigestionParams = GetListOfDistinctDigestionParams(CommonParameters, fileSettingsList.Select(b => SetAllFileSpecificCommonParams(CommonParameters, b)));
@@ -804,26 +804,19 @@ namespace TaskLayer
                         List<CompactPeptide> peptideIndex = null;
                         List<Protein> proteinListSubset = proteinList.GetRange(currentPartition * proteinList.Count() / combinedParams.TotalPartitions, ((currentPartition + 1) * proteinList.Count() / combinedParams.TotalPartitions) - (currentPartition * proteinList.Count() / combinedParams.TotalPartitions));
 
-                        float[] keys = null;
-                        List<int>[] fragmentIndex = null;
-
                         #region Generate indices for modern search
 
                         Status("Getting fragment dictionary...", new List<string> { taskId });
-                        var indexEngine = new IndexingEngine(proteinListSubset, variableModifications, fixedModifications, ionTypes, currentPartition, SearchParameters.DecoyType, ListOfDigestionParams, combinedParams.TotalPartitions, new List<string> { taskId });
-                        Dictionary<float, List<int>> fragmentIndexDict = new Dictionary<float, List<int>>();
+                        var indexEngine = new IndexingEngine(proteinListSubset, variableModifications, fixedModifications, ionTypes, currentPartition, SearchParameters.DecoyType, ListOfDigestionParams, combinedParams, SearchParameters.MaxFragmentSize, new List<string> { taskId });
+                        List<int>[] fragmentIndex = null;
                         lock (indexLock)
-                        {
-                            GenerateIndexes(indexEngine, dbFilenameList, ref peptideIndex, ref fragmentIndexDict, taskId);
-                        }
-                        keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-                        fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
+                            GenerateIndexes(indexEngine, dbFilenameList, ref peptideIndex, ref fragmentIndex, taskId);
 
                         #endregion Generate indices for modern search
 
                         Status("Searching files...", taskId);
 
-                        new ModernSearchEngine(fileSpecificPsms, arrayOfMs2ScansSortedByMass, peptideIndex, keys, fragmentIndex, ionTypes, currentPartition, combinedParams, SearchParameters.AddCompIons, massDiffAcceptor, thisId).Run();
+                        new ModernSearchEngine(fileSpecificPsms, arrayOfMs2ScansSortedByMass, peptideIndex, fragmentIndex, ionTypes, currentPartition, combinedParams, SearchParameters.AddCompIons, massDiffAcceptor, thisId).Run();
 
                         ReportProgress(new ProgressEventArgs(100, "Done with search " + (currentPartition + 1) + "/" + combinedParams.TotalPartitions + "!", thisId));
                     }
@@ -838,26 +831,20 @@ namespace TaskLayer
                             List<CompactPeptide> peptideIndex = null;
                             List<Protein> proteinListSubset = proteinList.GetRange(currentPartition * proteinList.Count() / combinedParams.TotalPartitions, ((currentPartition + 1) * proteinList.Count() / combinedParams.TotalPartitions) - (currentPartition * proteinList.Count() / combinedParams.TotalPartitions));
 
-                            float[] keys = null;
-                            List<int>[] fragmentIndex = null;
+                            List<int>[] fragmentIndex = new List<int>[1];
 
                             #region Generate indices for modern search
 
                             Status("Getting fragment dictionary...", new List<string> { taskId });
-                            var indexEngine = new IndexingEngine(proteinListSubset, variableModifications, fixedModifications, terminusSpecificIons, currentPartition, SearchParameters.DecoyType, ListOfDigestionParams, combinedParams.TotalPartitions, new List<string> { taskId });
-                            Dictionary<float, List<int>> fragmentIndexDict = new Dictionary<float, List<int>>();
+                            var indexEngine = new IndexingEngine(proteinListSubset, variableModifications, fixedModifications, terminusSpecificIons, currentPartition, SearchParameters.DecoyType, ListOfDigestionParams, combinedParams, SearchParameters.MaxFragmentSize, new List<string> { taskId });
                             lock (indexLock)
-                            {
-                                GenerateIndexes(indexEngine, dbFilenameList, ref peptideIndex, ref fragmentIndexDict, taskId);
-                            }
-                            keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-                            fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
+                                GenerateIndexes(indexEngine, dbFilenameList, ref peptideIndex, ref fragmentIndex, taskId);
 
                             #endregion Generate indices for modern search
 
                             Status("Searching files...", taskId);
 
-                            new NonSpecificEnzymeSearchEngine(fileSpecificPsms, arrayOfMs2ScansSortedByMass, peptideIndex, keys, fragmentIndex, terminusSpecificIons, currentPartition, combinedParams, SearchParameters.AddCompIons, massDiffAcceptor, thisId).Run();
+                            new NonSpecificEnzymeSearchEngine(fileSpecificPsms, arrayOfMs2ScansSortedByMass, peptideIndex, fragmentIndex, terminusSpecificIons, currentPartition, combinedParams, SearchParameters.AddCompIons, massDiffAcceptor, thisId).Run();
 
                             ReportProgress(new ProgressEventArgs(100, "Done with search " + (currentPartition + 1) + "/" + combinedParams.TotalPartitions + "!", thisId));
                         }
@@ -1304,9 +1291,9 @@ namespace TaskLayer
             }
         }
 
-        private static void WriteFragmentIndexNetSerializer(Dictionary<float, List<int>> fragmentIndex, string fragmentIndexFile)
+        private static void WriteFragmentIndexNetSerializer(List<int>[] fragmentIndex, string fragmentIndexFile)
         {
-            var messageTypes = GetSubclassesAndItself(typeof(Dictionary<float, List<int>>));
+            var messageTypes = GetSubclassesAndItself(typeof(List<int>[]));
             var ser = new NetSerializer.Serializer(messageTypes);
 
             using (var file = File.Create(fragmentIndexFile))
@@ -1360,7 +1347,7 @@ namespace TaskLayer
             return peptideWithSetModifications.OneBasedStartResidueInProtein + oneIsNterminus - 2;
         }
 
-        private void GenerateIndexes(IndexingEngine indexEngine, List<DbForTask> dbFilenameList, ref List<CompactPeptide> peptideIndex, ref Dictionary<float, List<int>> fragmentIndexDict, string taskId)
+        private void GenerateIndexes(IndexingEngine indexEngine, List<DbForTask> dbFilenameList, ref List<CompactPeptide> peptideIndex, ref List<int>[] fragmentIndex, string taskId)
         {
             string pathToFolderWithIndices = GetExistingFolderWithIndices(indexEngine, dbFilenameList);
 
@@ -1375,7 +1362,7 @@ namespace TaskLayer
                 Status("Running Index Engine...", new List<string> { taskId });
                 var indexResults = (IndexingResults)indexEngine.Run();
                 peptideIndex = indexResults.PeptideIndex;
-                fragmentIndexDict = indexResults.FragmentIndexDict;
+                fragmentIndex = indexResults.FragmentIndex;
 
                 Status("Writing peptide index...", new List<string> { taskId });
                 var peptideIndexFile = Path.Combine(output_folderForIndices, "peptideIndex.ind");
@@ -1384,7 +1371,7 @@ namespace TaskLayer
 
                 Status("Writing fragment index...", new List<string> { taskId });
                 var fragmentIndexFile = Path.Combine(output_folderForIndices, "fragmentIndex.ind");
-                WriteFragmentIndexNetSerializer(fragmentIndexDict, fragmentIndexFile);
+                WriteFragmentIndexNetSerializer(fragmentIndex, fragmentIndexFile);
                 SucessfullyFinishedWritingFile(fragmentIndexFile, new List<string> { taskId });
             }
             else
@@ -1396,10 +1383,10 @@ namespace TaskLayer
                     peptideIndex = (List<CompactPeptide>)ser.Deserialize(file);
 
                 Status("Reading fragment index...", new List<string> { taskId });
-                messageTypes = GetSubclassesAndItself(typeof(Dictionary<float, List<int>>));
+                messageTypes = GetSubclassesAndItself(typeof(List<int>[]));
                 ser = new NetSerializer.Serializer(messageTypes);
                 using (var file = File.OpenRead(Path.Combine(pathToFolderWithIndices, "fragmentIndex.ind")))
-                    fragmentIndexDict = (Dictionary<float, List<int>>)ser.Deserialize(file);
+                    fragmentIndex = (List<int>[])ser.Deserialize(file);
             }
         }
 

--- a/TaskLayer/TaskParameters/SearchParameters.cs
+++ b/TaskLayer/TaskParameters/SearchParameters.cs
@@ -22,6 +22,7 @@ namespace TaskLayer
             WritePrunedDatabase = false;
             KeepAllUniprotMods = true;
             MassDiffAcceptorType = MassDiffAcceptorType.OneMM;
+            MaxFragmentSize = 30000.0;
         }
 
         #endregion Public Constructors
@@ -45,6 +46,7 @@ namespace TaskLayer
         public bool DoQuantification { get; set; }
         public SearchType SearchType { get; set; }
         public string CustomMdac { get; set; }
+        public double MaxFragmentSize { get; set; }
 
         #endregion Public Properties
     }

--- a/Test/AddCompIonsTest.cs
+++ b/Test/AddCompIonsTest.cs
@@ -110,13 +110,9 @@ namespace Test
                 ConserveMemory = false,
                 ScoreCutoff = 1,
             };
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.TotalPartitions, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
 
             var indexResults = (IndexingResults)indexEngine.Run();
-            var peptideIndex = indexResults.PeptideIndex;
-            var fragmentIndexDict = indexResults.FragmentIndexDict;
-            var keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-            var fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
 
             bool DoPrecursorDeconvolution = true;
             bool UseProvidedPrecursorInfo = true;
@@ -129,11 +125,11 @@ namespace Test
             MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             Psm[] allPsmsArray = new Psm[listOfSortedms2Scans.Length];
-            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
+            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
 
             Psm[] allPsmsArray2 = new Psm[listOfSortedms2Scans.Length];
             SearchParameters.AddCompIons = true;
-            new ModernSearchEngine(allPsmsArray2, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
+            new ModernSearchEngine(allPsmsArray2, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
 
             // Single search mode
             Assert.AreEqual(allPsmsArray.Length, allPsmsArray2.Length);
@@ -145,7 +141,7 @@ namespace Test
 
             Assert.AreEqual(allPsmsArray[0].ScanNumber, allPsmsArray2[0].ScanNumber);
 
-            Assert.IsTrue(allPsmsArray2[0].Score < allPsmsArray[0].Score * 2 && allPsmsArray2[0].Score > allPsmsArray[0].Score + 3);
+            Assert.IsTrue(allPsmsArray2[0].Score <= allPsmsArray[0].Score * 2 && allPsmsArray2[0].Score > allPsmsArray[0].Score + 3);
         }
 
         [Test]
@@ -157,8 +153,8 @@ namespace Test
             //The below theoretical does not accurately represent B-Y ions
             double[] sorted_theoretical_product_masses_for_this_peptide = new double[] { precursorMass + (2 * Constants.protonMass) - 275.1350, precursorMass + (2 * Constants.protonMass) - 258.127, precursorMass + (2 * Constants.protonMass) - 257.1244, 50, 60, 70, 147.0764, precursorMass + (2 * Constants.protonMass) - 147.0764, precursorMass + (2 * Constants.protonMass) - 70, precursorMass + (2 * Constants.protonMass) - 60, precursorMass + (2 * Constants.protonMass) - 50, 257.1244, 258.127, 275.1350 }; //{ 50, 60, 70, 147.0764, 257.1244, 258.127, 275.1350 }
             List<ProductType> lp = new List<ProductType> { ProductType.B, ProductType.Y };
-            double scoreT = MetaMorpheusEngine.CalculateClassicScore(t.GetOneBasedScan(2), productMassTolerance, sorted_theoretical_product_masses_for_this_peptide, precursorMass, new List<DissociationType> { DissociationType.HCD }, true);
-            double scoreF = MetaMorpheusEngine.CalculateClassicScore(t.GetOneBasedScan(2), productMassTolerance, sorted_theoretical_product_masses_for_this_peptide, precursorMass, new List<DissociationType> { DissociationType.HCD }, false);
+            double scoreT = MetaMorpheusEngine.CalculatePeptideScore(t.GetOneBasedScan(2), productMassTolerance, sorted_theoretical_product_masses_for_this_peptide, precursorMass, new List<DissociationType> { DissociationType.HCD }, true);
+            double scoreF = MetaMorpheusEngine.CalculatePeptideScore(t.GetOneBasedScan(2), productMassTolerance, sorted_theoretical_product_masses_for_this_peptide, precursorMass, new List<DissociationType> { DissociationType.HCD }, false);
             Assert.IsTrue(scoreT == scoreF * 2 && scoreT > scoreF + 1);
         }
 

--- a/Test/IndexEngineTest.cs
+++ b/Test/IndexEngineTest.cs
@@ -46,7 +46,7 @@ namespace Test
                 ConserveMemory = false,
                 ScoreCutoff = 1,
             };
-            var engine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.BnoB1ions, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.TotalPartitions, new List<string>());
+            var engine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.BnoB1ions, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, 30000, new List<string>());
 
             var results = (IndexingResults)engine.Run();
 
@@ -100,14 +100,14 @@ namespace Test
                 ConserveMemory = false,
                 ScoreCutoff = 1,
             };
-            var engine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.BnoB1ions, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.TotalPartitions, new List<string>());
+            var engine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.BnoB1ions, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, 30000, new List<string>());
 
             var results = (IndexingResults)engine.Run();
 
             Assert.AreEqual(1, results.PeptideIndex.Count);
 
             Assert.IsNaN(results.PeptideIndex[0].MonoisotopicMassIncludingFixedMods);
-            Assert.AreEqual(2, results.FragmentIndexDict.Count);
+            Assert.AreEqual(30000000, results.FragmentIndex.Length);
         }
 
         #endregion Public Methods

--- a/Test/MyPeptideTest.cs
+++ b/Test/MyPeptideTest.cs
@@ -83,7 +83,7 @@ namespace Test
                 },
                 ProductMassTolerance = new PpmTolerance(5),
                 ConserveMemory = false,
-                ScoreCutoff = 0
+                ScoreCutoff = 1
             };
             ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), false, CommonParameters, new List<string>());
 
@@ -126,7 +126,7 @@ namespace Test
                     InitiatorMethionineBehavior = InitiatorMethionineBehavior.Retain,
                 },
                 ConserveMemory = false,
-                ScoreCutoff = 0
+                ScoreCutoff = 1
             };
             ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), false, CommonParameters, new List<string>());
 
@@ -168,7 +168,7 @@ namespace Test
                     InitiatorMethionineBehavior = InitiatorMethionineBehavior.Retain,
                 },
                 ConserveMemory = false,
-                ScoreCutoff = 0
+                ScoreCutoff = 1
             };
             ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), false, CommonParameters, new List<string>());
 
@@ -198,7 +198,7 @@ namespace Test
             IMsDataScanWithPrecursor<IMzSpectrum<IMzPeak>> scan = new MzmlScanWithPrecursor(1, massSpectrum, 1, true, Polarity.Positive, 1, new MzRange(300, 2000), "", MZAnalyzerType.Unknown, massSpectrum.SumOfAllY, 0, null, null, 0, null, DissociationType.Unknown, 1, null, null, "scan=1");
 
             Psm[] globalPsms = new Psm[1];
-            Ms2ScanWithSpecificMass[] arrayOfSortedMS2Scans = { new Ms2ScanWithSpecificMass(scan, new MzPeak(0, 0), 0, null) };
+            Ms2ScanWithSpecificMass[] arrayOfSortedMS2Scans = { new Ms2ScanWithSpecificMass(scan, new MzPeak(600, 1), 1, null) };
             CommonParameters CommonParameters = new CommonParameters
             {
                 ProductMassTolerance = new PpmTolerance(5),
@@ -210,15 +210,11 @@ namespace Test
                     InitiatorMethionineBehavior = InitiatorMethionineBehavior.Retain,
                 },
                 ConserveMemory = false,
-                ScoreCutoff = 0
+                ScoreCutoff = 1
             };
-            var indexEngine = new IndexingEngine(new List<Protein> { prot }, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.TotalPartitions, new List<string>());
+            var indexEngine = new IndexingEngine(new List<Protein> { prot }, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, 30000, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
-            var peptideIndex = indexResults.PeptideIndex;
-            var fragmentIndexDict = indexResults.FragmentIndexDict;
-            var keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-            var fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
-            var cse = new ModernSearchEngine(globalPsms, arrayOfSortedMS2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType>(), 0, CommonParameters, false, new OpenSearchMode(), new List<string>());
+            var cse = new ModernSearchEngine(globalPsms, arrayOfSortedMS2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, false, new OpenSearchMode(), new List<string>());
 
             cse.Run();
             Assert.Less(globalPsms[0].Score, 2);
@@ -257,7 +253,7 @@ namespace Test
                     InitiatorMethionineBehavior = InitiatorMethionineBehavior.Retain,
                 },
                 ConserveMemory = false,
-                ScoreCutoff = 0
+                ScoreCutoff = 1
             };
             ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), false, CommonParameters, new List<string>());
 

--- a/Test/SearchEngineTests.cs
+++ b/Test/SearchEngineTests.cs
@@ -159,12 +159,8 @@ namespace Test
 
             var proteinList = new List<Protein> { new Protein("MNNNKQQQ", null) };
 
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.TotalPartitions, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
-            var peptideIndex = indexResults.PeptideIndex;
-            var fragmentIndexDict = indexResults.FragmentIndexDict;
-            var keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-            var fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
 
             bool DoPrecursorDeconvolution = true;
             bool UseProvidedPrecursorInfo = true;
@@ -177,7 +173,7 @@ namespace Test
             MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             Psm[] allPsmsArray = new Psm[listOfSortedms2Scans.Length];
-            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType>(), 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
+            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
 
             // Single search mode
             Assert.AreEqual(1, allPsmsArray.Length);
@@ -208,7 +204,7 @@ namespace Test
                 {
                     Protease = new Protease("Custom Protease", new List<string> { "K" }, new List<string>(), TerminusType.C, CleavageSpecificity.Full, null, null, null),
                 },
-                ScoreCutoff = 1000
+                ScoreCutoff = 255
             };
 
             MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
@@ -236,12 +232,8 @@ namespace Test
 
             var searchModes = new SinglePpmAroundZeroSearchMode(5);
 
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.TotalPartitions, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
-            var peptideIndex = indexResults.PeptideIndex;
-            var fragmentIndexDict = indexResults.FragmentIndexDict;
-            var keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-            var fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
 
             bool DoPrecursorDeconvolution = true;
             bool UseProvidedPrecursorInfo = true;
@@ -257,10 +249,10 @@ namespace Test
             new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, false, CommonParameters, new List<string>()).Run();
 
             //Modern
-            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
+            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
 
             //NonSpecific
-            new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType> { ProductType.B }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
+            new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
         }
 
         [Test]
@@ -288,12 +280,8 @@ namespace Test
 
             var proteinList = new List<Protein> { new Protein("MNNNKQXQ", null) };
 
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.TotalPartitions, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
-            var peptideIndex = indexResults.PeptideIndex;
-            var fragmentIndexDict = indexResults.FragmentIndexDict;
-            var keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-            var fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
 
             bool DoPrecursorDeconvolution = true;
             bool UseProvidedPrecursorInfo = true;
@@ -305,7 +293,7 @@ namespace Test
             MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             Psm[] allPsmsArray = new Psm[listOfSortedms2Scans.Length];
-            var engine = new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType>(), 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>());
+            var engine = new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>());
             var searchResults = engine.Run();
 
             // Single search mode
@@ -363,12 +351,10 @@ namespace Test
             var proteinList = new List<Protein> { new Protein("GGGGGMNNNKQQQGGGGG", "TestProtein") };
 
             CommonParameters.DigestionParams.MinPeptideLength = null;
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.TotalPartitions, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
             var peptideIndex = indexResults.PeptideIndex;
-            var fragmentIndexDict = indexResults.FragmentIndexDict;
-            var keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-            var fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
+            var fragmentIndexDict = indexResults.FragmentIndex;
 
             bool DoPrecursorDeconvolution = true;
             bool UseProvidedPrecursorInfo = true;
@@ -382,8 +368,7 @@ namespace Test
 
             Psm[] allPsmsArray = new Psm[listOfSortedms2Scans.Length];
             CommonParameters.DigestionParams.MinPeptideLength = 5;
-
-            new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType> { ProductType.B }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
+            new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, new List<ProductType> { ProductType.B }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>()).Run();
 
             // Single search mode
             Assert.AreEqual(1, allPsmsArray.Length);
@@ -420,7 +405,7 @@ namespace Test
                     Protease = new Protease("singleC", new List<string> { "K, G" }, new List<string>(), TerminusType.None, CleavageSpecificity.SingleC, null, null, null),
                 },
                 ConserveMemory = false,
-                ScoreCutoff = 1,
+                ScoreCutoff = 4,
                 PrecursorMassTolerance = new PpmTolerance(5),
             };
 
@@ -446,13 +431,11 @@ namespace Test
             var proteinList = new List<Protein> { new Protein("GGGGGMNNNKQQQGGGGG", null) };
             CommonParameters.DigestionParams.MinPeptideLength = null;
 
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.TotalPartitions, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
 
             var indexResults = (IndexingResults)indexEngine.Run();
             var peptideIndex = indexResults.PeptideIndex;
-            var fragmentIndexDict = indexResults.FragmentIndexDict;
-            var keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-            var fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
+            var fragmentIndexDict = indexResults.FragmentIndex;
 
             bool DoPrecursorDeconvolution = true;
             bool UseProvidedPrecursorInfo = true;
@@ -465,9 +448,7 @@ namespace Test
 
             Psm[] allPsmsArray = new Psm[listOfSortedms2Scans.Length];
             CommonParameters.DigestionParams.MinPeptideLength = 5;
-
-            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType> { ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>());
-
+            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, new List<ProductType> { ProductType.Y }, 0, CommonParameters, SearchParameters.AddCompIons, massDiffAcceptor, new List<string>());
             var searchResults = engine.Run();
 
             // Single search mode
@@ -585,6 +566,7 @@ namespace Test
 
             CommonParameters CommonParameters = new CommonParameters
             {
+                ScoreCutoff = 1,
                 ProductMassTolerance = productMassTolerance,
                 YIons = false,
             };
@@ -597,12 +579,10 @@ namespace Test
                 TerminusTypeSemiProtease = TerminusType.N
             };
             HashSet<DigestionParams> digestParams = new HashSet<DigestionParams> { CommonParameters.DigestionParams };
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B }, 1, DecoyType.Reverse, digestParams, 1, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B }, 1, DecoyType.Reverse, digestParams, CommonParameters, 30000, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
             var peptideIndex = indexResults.PeptideIndex;
-            var fragmentIndexDict = indexResults.FragmentIndexDict;
-            var keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-            var fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
+            var fragmentIndexDict = indexResults.FragmentIndex;
 
             bool DoPrecursorDeconvolution = true;
             bool UseProvidedPrecursorInfo = true;
@@ -613,7 +593,7 @@ namespace Test
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
             Psm[] allPsmsArray = new Psm[listOfSortedms2Scans.Length];
-            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType> { ProductType.B }, 1, CommonParameters, true, searchModes, new List<string>());
+            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, new List<ProductType> { ProductType.B }, 1, CommonParameters, true, searchModes, new List<string>());
             var searchResults = engine.Run();
 
             // Single search mode
@@ -665,6 +645,7 @@ namespace Test
 
             CommonParameters CommonParameters = new CommonParameters
             {
+                ScoreCutoff = 1,
                 ProductMassTolerance = productMassTolerance,
                 BIons = false
             };
@@ -677,12 +658,10 @@ namespace Test
                 TerminusTypeSemiProtease = TerminusType.C
             };
             HashSet<DigestionParams> digestParams = new HashSet<DigestionParams> { CommonParameters.DigestionParams };
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.Y }, 1, DecoyType.Reverse, digestParams, 1, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.Y }, 1, DecoyType.Reverse, digestParams, CommonParameters, 30000, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
             var peptideIndex = indexResults.PeptideIndex;
-            var fragmentIndexDict = indexResults.FragmentIndexDict;
-            var keys = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Key).ToArray();
-            var fragmentIndex = fragmentIndexDict.OrderBy(b => b.Key).Select(b => b.Value).ToArray();
+            var fragmentIndexDict = indexResults.FragmentIndex;
 
             bool DoPrecursorDeconvolution = true;
             bool UseProvidedPrecursorInfo = true;
@@ -693,7 +672,7 @@ namespace Test
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
             Psm[] allPsmsArray = new Psm[listOfSortedms2Scans.Length];
-            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, keys, fragmentIndex, new List<ProductType> { ProductType.Y }, 1, CommonParameters, true, searchModes, new List<string>());
+            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, new List<ProductType> { ProductType.Y }, 1, CommonParameters, true, searchModes, new List<string>());
             var searchResults = engine.Run();
 
             // Single search mode

--- a/Test/packages.config
+++ b/Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FlashLFQ" version="0.1.95" targetFramework="net461" />
+  <package id="FlashLFQ" version="0.1.98" targetFramework="net461" />
   <package id="MathNet.Numerics" version="3.20.0" targetFramework="net451" />
   <package id="mzLib" version="1.0.246" targetFramework="net461" />
   <package id="Nett" version="0.8.0" targetFramework="net451" />


### PR DESCRIPTION
* Fix Modern Search Crash, generate unit test to prevent crash in future, renamed NonSpecificEnzymeEngine to NonSpecificEnzymeSearchEngine

* update modern search

* compiles

* fds

* qwe

* fix

* Crash proof CompactPeptideBase.Equals()

* cleanup

* fixed ambiguity in modern search

* test

* fixed bug in unit test

* tests

* test changes

* Add new massDiffAcceptors. Preliminary improvements to ModernSearch.

* modern search updates

* 50 aa maximum peptide size by default

* fix and add open MassAcceptors

* Little edits

* Reimplemented Complementary Ions

* Compile worthy NonSpecific Enzyme search

* Implemented nonspecific, fixed unit tests, implemented close experimentals in modern search.

* Implementation of absolute fragment mass errors, complementary ion simplification.

* some comments and setting up to look at multiple charge states on fragments

* Clean up experiments

* cleanup

* 10% increased speed

* Implement notches in ModernSearchEngine

* Renaming for clarity

* touch up

* Fix fragmentIndex for nonspecific in search task.

* A seemingly useless yet oddly important bit of code.

* NSE fixes

* Update Unit test

* update mzlib

* update nett

* fds

* fdssdg

* fixed notch issue

* sdg

* Update ClassicSearchEngine.cs

* merge fixes, bug fixes

* mass-fragment index instead of mz-fragment; update other small things

* edits

* added max fragment size to gui (used if modern search is enabled)

* fix

* sdf

* Cloof

* fixes

* zloof

* cleanup

* mhm

* aha

* Hmm

* fff