### PR TITLE
fix(parallelsearch): select detected organisms by evidence family, not test ratio

### DIFF
--- a/MetaMorpheus/TaskLayer/ParallelSearch/ParallelSearchTask.cs
+++ b/MetaMorpheus/TaskLayer/ParallelSearch/ParallelSearchTask.cs
@@ -1429,17 +1429,17 @@ public class ParallelSearchTask : SearchTask
          // Write global summary text file
          WriteGlobalResultsText(_resultsManager.TransientDatabaseMetricsDictionary, outputFolder, taskId, numFiles);
 
-        // Deal with custom reduced database writing
-        // TODO: Revise this to only be the family one. 
-        bool useFamilyRanking = ParallelSearchParameters.UseFamilyAwareRanking;
-        var statsByDatabase = useFamilyRanking
-            ? SelectDatabasesForWritingByFamily()
-            : SelectDatabasesForWritingByTestRatio();
+        // Deal with custom reduced database writing.
+        // Always use the family-aware gate (combined q-value + a minimum number of evidence families).
+        // The old test-ratio gate required passing >=50% of ALL tests, which even a perfect spike-in
+        // (SARS-CoV-2 passed 31/78) can't clear — many sub-tests structurally cannot fire for a small
+        // genome (NullEvidence / Undefined / BelowEligibilityThreshold), so nothing was ever written.
+        var statsByDatabase = SelectDatabasesForWritingByFamily();
 
          Task[] dbWritingTasks = new Task[3];
          if (statsByDatabase.Count > 0)
          {
-              Log($"Found {statsByDatabase.Count} significant databases passing cutoff (mode: {(useFamilyRanking ? "family-aware" : "test-ratio")})", [taskId]);
+              Log($"Found {statsByDatabase.Count} significant databases passing cutoff (family-aware, >={MinFamiliesForSignificance}/7 families)", [taskId]);
 
             dbWritingTasks[0] = ParallelSearchParameters.DatabasesToWriteAndSearch[DatabaseToProduce.AllSignificantOrganisms].Write
                 ? Task.Run(() => CreateCombinedDatabaseWithAllProteins(taskId, statsByDatabase.Select(p => p.Key), outputFolder))
@@ -1472,30 +1472,49 @@ public class ParallelSearchTask : SearchTask
                 p => p.OrderBy(t => t.ToString()).ToList());
     }
 
+    /// <summary>Minimum number (of 7) of independent evidence families a database must pass to be written
+    /// as a confidently-detected organism.
+    /// NOTE on tuning: on the SARS virus spike-in, SARS-CoV-2 passes 7/7 and SARS-CoV 5/7, while a tail of
+    /// phage databases that floor out at the combined-q value only reach 4/7. So a bar of 4 admits that phage
+    /// tail (more sensitive, noisier) and a bar of 5 isolates the genuine detections. Left at 4 by request;
+    /// raise to 5 if the phage tail proves to be false positives.</summary>
+    private const int MinFamiliesForSignificance = 4;
+
     private Dictionary<DbForTask, List<StatisticalTestResult>> SelectDatabasesForWritingByFamily()
     {
         double qValueThreshold = CommonParameters.QValueThreshold;
-        int minFamilyPasses = Math.Max(1, ParallelSearchParameters.TestRatioForWriting > 0
-            ? (int)Math.Ceiling(ParallelSearchParameters.TestRatioForWriting * 7)
-            : 1);
+        int minFamilyPasses = MinFamiliesForSignificance;
+        const double significanceAlpha = 0.05;
+        const string overallCombinedMetric = "All"; // CombinedResultNames.AllMetricName
 
+        // Resolve the source DbForTask for a database tag. In merged-index mode TransientDatabases holds only the
+        // single merged .msl, so there is no per-organism DbForTask — synthesize one keyed by the db tag.
+        DbForTask ResolveDb(string dbTag) =>
+            ParallelSearchParameters.TransientDatabases.FirstOrDefault(db => Path.GetFileNameWithoutExtension(db.FileName) == dbTag)
+            ?? new DbForTask(dbTag, false);
+
+        // Compute passed-family count and the overall combined q-value DIRECTLY from the test results — the same
+        // source the StatisticalAnalysis_Results.csv uses — rather than the metrics-summary fields, which are not
+        // reliably populated for this writer (and were silently selecting nothing, even for SARS-CoV-2 at 7/7).
         return _resultsManager!.StatisticalTestResultList
             .GroupBy(p => p.DatabaseName)
-            .Where(p =>
+            .Where(g =>
             {
-                if (!_resultsManager!.TransientDatabaseMetricsDictionary.TryGetValue(p.Key, out var metrics))
-                    return false;
-
-                int passedFamilies = metrics.PassedFamilyCount;
-                double combinedQ = metrics.CombinedQValue;
-
+                int passedFamilies = g
+                    .Where(r => !r.IsCombinedResult && r.EvidenceFamily.HasValue && r.IsSignificant(significanceAlpha))
+                    .Select(r => r.EvidenceFamily!.Value)
+                    .Distinct()
+                    .Count();
+                double combinedQ = g
+                    .Where(r => r.IsCombinedResult && r.MetricName == overallCombinedMetric)
+                    .Select(r => r.QValue)
+                    .DefaultIfEmpty(double.NaN)
+                    .First();
                 return passedFamilies >= minFamilyPasses
                     && !double.IsNaN(combinedQ)
                     && combinedQ <= qValueThreshold;
             })
-            .ToDictionary(
-                p => ParallelSearchParameters.TransientDatabases.First(db => Path.GetFileNameWithoutExtension(db.FileName) == p.Key),
-                p => p.OrderBy(t => t.ToString()).ToList());
+            .ToDictionary(g => ResolveDb(g.Key), g => g.OrderBy(t => t.ToString()).ToList());
     }
 
 

--- a/MetaMorpheus/TaskLayer/ParallelSearch/ParallelSearchTask.cs
+++ b/MetaMorpheus/TaskLayer/ParallelSearch/ParallelSearchTask.cs
@@ -1484,37 +1484,44 @@ public class ParallelSearchTask : SearchTask
     {
         double qValueThreshold = CommonParameters.QValueThreshold;
         int minFamilyPasses = MinFamiliesForSignificance;
-        const double significanceAlpha = 0.05;
-        const string overallCombinedMetric = "All"; // CombinedResultNames.AllMetricName
-
         // Resolve the source DbForTask for a database tag. In merged-index mode TransientDatabases holds only the
         // single merged .msl, so there is no per-organism DbForTask — synthesize one keyed by the db tag.
         DbForTask ResolveDb(string dbTag) =>
             ParallelSearchParameters.TransientDatabases.FirstOrDefault(db => Path.GetFileNameWithoutExtension(db.FileName) == dbTag)
             ?? new DbForTask(dbTag, false);
 
-        // Compute passed-family count and the overall combined q-value DIRECTLY from the test results — the same
-        // source the StatisticalAnalysis_Results.csv uses — rather than the metrics-summary fields, which are not
-        // reliably populated for this writer (and were silently selecting nothing, even for SARS-CoV-2 at 7/7).
         return _resultsManager!.StatisticalTestResultList
             .GroupBy(p => p.DatabaseName)
-            .Where(g =>
-            {
-                int passedFamilies = g
-                    .Where(r => !r.IsCombinedResult && r.EvidenceFamily.HasValue && r.IsSignificant(significanceAlpha))
-                    .Select(r => r.EvidenceFamily!.Value)
-                    .Distinct()
-                    .Count();
-                double combinedQ = g
-                    .Where(r => r.IsCombinedResult && r.MetricName == overallCombinedMetric)
-                    .Select(r => r.QValue)
-                    .DefaultIfEmpty(double.NaN)
-                    .First();
-                return passedFamilies >= minFamilyPasses
-                    && !double.IsNaN(combinedQ)
-                    && combinedQ <= qValueThreshold;
-            })
+            .Where(g => QualifiesAsDetectedOrganism(g, minFamilyPasses, qValueThreshold))
             .ToDictionary(g => ResolveDb(g.Key), g => g.OrderBy(t => t.ToString()).ToList());
+    }
+
+    /// <summary>
+    /// The family-aware detection predicate (extracted for testing): a database qualifies as a confidently
+    /// detected organism when at least <paramref name="minFamilyPasses"/> independent evidence families are
+    /// significant AND the overall combined q-value is at or below <paramref name="qValueThreshold"/>. Both
+    /// quantities are computed DIRECTLY from the test results — the same source StatisticalAnalysis_Results.csv
+    /// uses — rather than from the metrics-summary fields, which are not reliably populated for this writer
+    /// (and were silently selecting nothing, even for SARS-CoV-2 at 7/7).
+    /// </summary>
+    internal static bool QualifiesAsDetectedOrganism(
+        IEnumerable<StatisticalTestResult> dbResults, int minFamilyPasses, double qValueThreshold,
+        double significanceAlpha = 0.05, string overallCombinedMetric = "All")
+    {
+        var results = dbResults as ICollection<StatisticalTestResult> ?? dbResults.ToList();
+        int passedFamilies = results
+            .Where(r => !r.IsCombinedResult && r.EvidenceFamily.HasValue && r.IsSignificant(significanceAlpha))
+            .Select(r => r.EvidenceFamily!.Value)
+            .Distinct()
+            .Count();
+        double combinedQ = results
+            .Where(r => r.IsCombinedResult && r.MetricName == overallCombinedMetric)
+            .Select(r => r.QValue)
+            .DefaultIfEmpty(double.NaN)
+            .First();
+        return passedFamilies >= minFamilyPasses
+            && !double.IsNaN(combinedQ)
+            && combinedQ <= qValueThreshold;
     }
 
 

--- a/MetaMorpheus/Test/ParallelSearchTask/FamilyDetectionTests.cs
+++ b/MetaMorpheus/Test/ParallelSearchTask/FamilyDetectionTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using TaskLayer.ParallelSearch.Statistics;
+using PST = TaskLayer.ParallelSearch.ParallelSearchTask;
+
+namespace Test.ParallelSearchTask;
+
+/// <summary>
+/// Tests the family-aware organism-detection predicate: a database is a confident detection when at least
+/// N independent evidence families are significant AND the overall combined q-value clears the threshold.
+/// This replaced the test-ratio gate that required passing >=50% of ALL tests — unreachable for a small
+/// genome (SARS-CoV-2 passed 31/78), so nothing was ever written.
+/// </summary>
+[TestFixture]
+public class FamilyDetectionTests
+{
+    private const int MinFamilies = 4;
+    private const double QThreshold = 0.01;
+
+    private static StatisticalTestResult Family(StatisticalEvidenceFamily fam, double qValue) => new()
+    {
+        TestName = "GaussianTest", // not a combined name -> IsCombinedResult == false
+        MetricName = fam.ToString(),
+        EvidenceFamily = fam,
+        IsDefined = true,
+        QValue = qValue,
+    };
+
+    private static StatisticalTestResult OverallCombined(double qValue, string metric = "All") => new()
+    {
+        TestName = "Combined", // IsCombinedResult == true
+        MetricName = metric,
+        IsDefined = true,
+        QValue = qValue,
+    };
+
+    private static readonly StatisticalEvidenceFamily[] SevenFamilies =
+    {
+        StatisticalEvidenceFamily.CountEnrichment,
+        StatisticalEvidenceFamily.AmbiguityOrTargetDecoy,
+        StatisticalEvidenceFamily.ScoreDistribution,
+        StatisticalEvidenceFamily.Fragmentation,
+        StatisticalEvidenceFamily.RetentionTime,
+        StatisticalEvidenceFamily.ProteinGroup,
+        StatisticalEvidenceFamily.PrecursorDeconvolution,
+    };
+
+    [Test]
+    public void StrongDetection_AllFamiliesSignificant_Qualifies()
+    {
+        var results = new List<StatisticalTestResult>();
+        foreach (var f in SevenFamilies) results.Add(Family(f, 1e-300));
+        results.Add(OverallCombined(4.7e-300));
+
+        Assert.That(PST.QualifiesAsDetectedOrganism(results, MinFamilies, QThreshold), Is.True);
+    }
+
+    [Test]
+    public void TooFewFamilies_DoesNotQualify()
+    {
+        var results = new List<StatisticalTestResult>
+        {
+            Family(StatisticalEvidenceFamily.CountEnrichment, 1e-50),
+            Family(StatisticalEvidenceFamily.Fragmentation, 1e-50),
+            Family(StatisticalEvidenceFamily.RetentionTime, 1e-50), // only 3 distinct families
+            OverallCombined(1e-100),
+        };
+        Assert.That(PST.QualifiesAsDetectedOrganism(results, MinFamilies, QThreshold), Is.False);
+    }
+
+    [Test]
+    public void CombinedQOverThreshold_DoesNotQualify()
+    {
+        var results = new List<StatisticalTestResult>();
+        for (int i = 0; i < 5; i++) results.Add(Family(SevenFamilies[i], 1e-50));
+        results.Add(OverallCombined(0.02)); // 5 families pass but combined q 0.02 > 0.01
+
+        Assert.That(PST.QualifiesAsDetectedOrganism(results, MinFamilies, QThreshold), Is.False);
+    }
+
+    [Test]
+    public void NoOverallCombinedResult_NaN_DoesNotQualify()
+    {
+        var results = new List<StatisticalTestResult>();
+        for (int i = 0; i < 5; i++) results.Add(Family(SevenFamilies[i], 1e-50)); // families pass, but no "All" combined
+
+        Assert.That(PST.QualifiesAsDetectedOrganism(results, MinFamilies, QThreshold), Is.False);
+    }
+
+    [Test]
+    public void InsignificantFamilyResults_DoNotCountTowardFamilies()
+    {
+        var results = new List<StatisticalTestResult>();
+        foreach (var f in SevenFamilies) results.Add(Family(f, 0.5)); // present but NOT significant
+        results.Add(OverallCombined(1e-300));
+
+        Assert.That(PST.QualifiesAsDetectedOrganism(results, MinFamilies, QThreshold), Is.False);
+    }
+
+    [Test]
+    public void PerFamilyCombined_NotTreatedAsOverall()
+    {
+        // A combined result for a single family (MetricName != "All") must NOT supply the overall combined q.
+        var results = new List<StatisticalTestResult>();
+        for (int i = 0; i < 5; i++) results.Add(Family(SevenFamilies[i], 1e-50));
+        results.Add(OverallCombined(1e-300, metric: "CountEnrichment")); // per-family combined, not the overall
+
+        Assert.That(PST.QualifiesAsDetectedOrganism(results, MinFamilies, QThreshold), Is.False);
+    }
+
+    [Test]
+    public void DuplicateSignificantFamily_CountsOnce()
+    {
+        // Same family significant twice should count as ONE family, so 3 distinct families < 4 -> no.
+        var results = new List<StatisticalTestResult>
+        {
+            Family(StatisticalEvidenceFamily.CountEnrichment, 1e-50),
+            Family(StatisticalEvidenceFamily.CountEnrichment, 1e-60), // duplicate family
+            Family(StatisticalEvidenceFamily.Fragmentation, 1e-50),
+            Family(StatisticalEvidenceFamily.RetentionTime, 1e-50),
+            OverallCombined(1e-100),
+        };
+        Assert.That(PST.QualifiesAsDetectedOrganism(results, MinFamilies, QThreshold), Is.False);
+    }
+}

--- a/MetaMorpheus/Test/ParallelSearchTask/ParallelSearchEndToEndTests.cs
+++ b/MetaMorpheus/Test/ParallelSearchTask/ParallelSearchEndToEndTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using EngineLayer.DatabaseLoading;
+using NUnit.Framework;
+using TaskLayer;
+using PSTask = TaskLayer.ParallelSearch.ParallelSearchTask;
+
+namespace Test.ParallelSearchTask;
+
+/// <summary>
+/// End-to-end smoke test that drives a real ParallelSearchTask once over small bundled data, so the
+/// orchestration that the focused unit tests can't reach — base search, PEP training, the per-database
+/// search + PEP assignment + confident-output writing, the statistics, and the family-aware writer — is
+/// exercised. Base db = smalldb.fasta (the search that feeds PEP training); transient db = gapdh.fasta
+/// (abundant yeast GAPDH, so the transient search produces hits).
+/// </summary>
+[TestFixture]
+public class ParallelSearchEndToEndTests
+{
+    [Test]
+    public void RunTask_SmallYeast_ProducesSummaryWithPepColumns()
+    {
+        string testData = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData");
+        string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "ParallelSearchE2E");
+        if (Directory.Exists(outputFolder))
+            Directory.Delete(outputFolder, true);
+        Directory.CreateDirectory(outputFolder);
+
+        // Work on copies of the spectra file (the search writes file-specific artifacts next to it). Two copies
+        // are pooled into the base search so it clears the >=100-PSM bar that gates PEP-model training.
+        string src = Path.Combine(testData, "SmallCalibratible_Yeast.mzML");
+        string mzml1 = Path.Combine(outputFolder, "Yeast_1.mzML");
+        string mzml2 = Path.Combine(outputFolder, "Yeast_2.mzML");
+        File.Copy(src, mzml1, true);
+        File.Copy(src, mzml2, true);
+
+        string baseDb = Path.Combine(testData, "smalldb.fasta");        // base (yeast) -> PEP training set
+        string transientDb = Path.Combine(testData, "smalldb.fasta");   // transient db (same yeast proteins) -> guaranteed hits
+
+        var task = new PSTask(new List<DbForTask> { new DbForTask(transientDb, false) });
+        task.ParallelSearchParameters.MaxSearchesInParallel = 1;
+
+        Assert.DoesNotThrow(() =>
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(baseDb, false) }, new List<string> { mzml1, mzml2 }, "test"));
+
+        // The cross-database summary must have been written, and must carry the new PEP 1%/5% columns.
+        var summary = Directory.EnumerateFiles(outputFolder, "ManySearchSummary.csv", SearchOption.AllDirectories).FirstOrDefault();
+        Assert.That(summary, Is.Not.Null, "ManySearchSummary.csv was not written");
+
+        var lines = File.ReadAllLines(summary);
+        var header = lines[0].Split(',');
+        int Col(string name) => System.Array.IndexOf(header, name);
+        Assert.Multiple(() =>
+        {
+            Assert.That(Col("TargetPeptidesFromTransientDbAtPepQ01"), Is.GreaterThanOrEqualTo(0));
+            Assert.That(Col("TargetPeptidesFromTransientDbAtPepQ05"), Is.GreaterThanOrEqualTo(0));
+            Assert.That(Col("TargetPsmsFromTransientDbAtPepQ01"), Is.GreaterThanOrEqualTo(0));
+            Assert.That(Col("TargetPsmsFromTransientDbAtPepQ05"), Is.GreaterThanOrEqualTo(0));
+        });
+
+        var row = lines.Skip(1).First(l => l.Trim().Length > 0).Split(',');
+        int transientPep = int.Parse(row[Col("TargetPeptidesFromTransientDb")]);
+        int pepQ05 = int.Parse(row[Col("TargetPeptidesFromTransientDbAtPepQ05")]);
+
+        // The transient search produced hits, and the base-trained PEP model assigned a confident PEP_QValue to
+        // them (this is what fails if PEP training or the per-database PEP-assignment block stops running).
+        Assert.That(transientPep, Is.GreaterThanOrEqualTo(1), "transient search should produce hits");
+        Assert.That(pepQ05, Is.GreaterThanOrEqualTo(1), "PEP model should assign a confident PEP_QValue to transient peptides");
+    }
+}


### PR DESCRIPTION
## Summary
Select confidently-detected organisms by **independent evidence families** (≥4 of 7 families significant AND combined q ≤ threshold) instead of the old test-ratio gate (pass ≥50% of all tests). Compute passed-families and the combined q-value **directly from the statistical test results** — the same source `StatisticalAnalysis_Results.csv` uses — rather than from in-memory summary fields that weren't reliably populated for this writer, and synthesize a database key so it works with the merged index. Also sanitizes NaN/Inf in the anomaly-detection features.

## Benefits
The organism call is now actually emitted. On the SARS spike-in, SARS-CoV-2 is correctly selected (7/7 families, combined q = 4.7e-300, anomaly rank #1), with SARS-CoV (its sister coronavirus) right behind — where the previous gate selected **nothing**.

## Rationale
The test-ratio gate required passing ≥50% of all 78 tests, but many sub-tests structurally cannot fire for a small viral genome (NullEvidence / Undefined / BelowEligibilityThreshold), so even a perfect spike-in (SARS-CoV-2, 31/78) never cleared the bar. Family-level evidence with a combined-q cutoff asks "is this organism supported across independent lines of evidence?" instead of "did an arbitrary fraction of all tests fire?". Reading from the results also fixes a populate-ordering bug, and the synthetic key fixes a latent merged-mode crash.

## Tests
7 unit tests for the extracted `QualifiesAsDetectedOrganism` predicate: a strong all-families detection qualifies; too few significant families is rejected; a combined q over threshold is rejected; a missing overall-combined result (NaN) is rejected; insignificant family results do not count; a per-family combined result (`MetricName != "All"`) is not mistaken for the overall combined; and a duplicate significant family counts once. The end-to-end `RunTask` test (in PR 4) additionally exercises this writer on a live pipeline.

---
**Stacked series**: base is `parallelsearch-pep` (PR 4). Independent of PR 3 (MSL) and conceptually independent of PR 4 — stacked only to keep the shared `ParallelSearchTask.cs` edits conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
