### PR TITLE
feat(msl): support .msl spectral libraries in MetaDraw

### DIFF
--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -41,7 +41,7 @@ namespace MetaMorpheusGUI
         public PtmLegendViewModel PtmLegend;
         private ObservableCollection<ModTypeForTreeViewModel> Modifications = new ObservableCollection<ModTypeForTreeViewModel>();
         private static List<string> AcceptedResultsFormats = new List<string> { ".psmtsv", ".osmtsv", ".tsv" };
-        private static List<string> AcceptedSpectralLibraryFormats = new List<string> { ".msp" };
+        private static List<string> AcceptedSpectralLibraryFormats = new List<string> { ".msp", ".msl" };
         private FragmentationReanalysisViewModel FragmentationReanalysisViewModel;
         public ChimeraAnalysisTabViewModel ChimeraAnalysisTabViewModel { get; set; }
         public DeconExplorationTabViewModel DeconExplorationViewModel { get; set; }

--- a/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
+++ b/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
@@ -1578,6 +1578,81 @@ namespace Test.MetaDraw
         }
 
         [Test]
+        public static void TestMetaDrawWithMslSpectralLibrary()
+        {
+            // Verifies MetaDraw consumes a binary .msl spectral library exactly as it does a text
+            // .msp library: the same library peaks are rendered in the mirror plot. The .msl files
+            // are produced here from the existing .msp test libraries (so no new binary fixture is
+            // committed), then loaded through the unchanged MetaDrawLogic / MetaDrawDataLoader path —
+            // mzLib's SpectralLibrary routes .msl transparently.
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestMetaDrawWithMslSpectraLibrary");
+            string proteinDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SpectralLibrarySearch\P16858.fasta");
+            string mspLibrary1 = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SpectralLibrarySearch\P16858_target.msp");
+            string mspLibrary2 = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SpectralLibrarySearch\P16858_decoy.msp");
+            string spectraFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SpectralLibrarySearch\slicedMouse.raw");
+
+            Directory.CreateDirectory(outputFolder);
+
+            // Convert the .msp test libraries to binary .msl for MetaDraw to load.
+            string mslLibrary1 = Path.Combine(outputFolder, "P16858_target.msl");
+            string mslLibrary2 = Path.Combine(outputFolder, "P16858_decoy.msl");
+            Readers.SpectralLibrary.MslWriter.WriteFromLibrarySpectra(mslLibrary1,
+                new Readers.SpectralLibrary.SpectralLibrary(new List<string> { mspLibrary1 }).GetAllLibrarySpectra().ToList());
+            Readers.SpectralLibrary.MslWriter.WriteFromLibrarySpectra(mslLibrary2,
+                new Readers.SpectralLibrary.SpectralLibrary(new List<string> { mspLibrary2 }).GetAllLibrarySpectra().ToList());
+
+            // run search task (libraries supplied as .msp; produces the PSM file MetaDraw displays)
+            var searchtask = new SearchTask();
+            searchtask.RunTask(outputFolder,
+                new List<DbForTask>
+                {
+                    new DbForTask(proteinDatabase, false),
+                    new DbForTask(mspLibrary1, false),
+                    new DbForTask(mspLibrary2, false),
+                },
+                new List<string> { spectraFile }, "");
+
+            var psmFile = Path.Combine(outputFolder, @"AllPSMs.psmtsv");
+
+            // load results into metadraw, pointing the spectral library at the .msl files
+            var metadrawLogic = new MetaDrawLogic();
+            metadrawLogic.SpectraFilePaths.Add(spectraFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralLibraryPaths.Add(mslLibrary1);
+            metadrawLogic.SpectralLibraryPaths.Add(mslLibrary2);
+            var errors = metadrawLogic.LoadFiles(true, true);
+
+            Assert.That(!errors.Any());
+
+            // draw PSM
+            var plotView = new OxyPlot.Wpf.PlotView() { Name = "plotView" };
+            var scrollableCanvas = new Canvas();
+            var stationaryCanvas = new Canvas();
+            var sequenceAnnotationCanvas = new Canvas();
+            var parentChildView = new ParentChildScanPlotsView();
+            var psm = metadrawLogic.FilteredListOfPsms.First();
+
+            MetaDrawSettings.FirstAAonScreenIndex = 0;
+            MetaDrawSettings.NumberOfAAOnScreen = metadrawLogic.FilteredListOfPsms.First().BaseSeq.Length;
+            metadrawLogic.DisplaySequences(stationaryCanvas, scrollableCanvas, sequenceAnnotationCanvas, psm);
+            metadrawLogic.DisplaySpectrumMatch(plotView, psm, parentChildView, out errors);
+            Assert.That(errors == null || !errors.Any());
+
+            // library peaks (negative intensities in the mirror plot) were drawn from the .msl library —
+            // identical count to the .msp library in TestMetaDrawWithSpectralLibrary, confirming lossless display
+            var plotSeries = plotView.Model.Series;
+            var mirrorPlotPeaks = plotSeries.Where(p => ((LineSeries)p).Points[1].Y < 0).ToList();
+            Assert.That(mirrorPlotPeaks.Count == 52);
+
+            // clean up resources
+            metadrawLogic.CleanUpResources();
+            Assert.That(!metadrawLogic.SpectralLibraryPaths.Any());
+
+            // delete output
+            Directory.Delete(outputFolder, true);
+        }
+
+        [Test]
         public static void TestPsmFromTsvIonParsing()
         {
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestPsmFromTsvIonParsing");


### PR DESCRIPTION
Builds on #2674 (which adds .msl as a search database). This PR enables the same `.msl` binary spectral libraries to be opened in **MetaDraw** for visualization, addressing @nbollis's review comment on #2674.

> You should also enable support in MetaDraw. This will likely involve a change in MetaDraw.xaml.cs, MetaDrawLogic.cs and MetaDrawDataLoader.cs

### Change (light touch)
- **`MetaDraw.xaml.cs`** — add `.msl` to `AcceptedSpectralLibraryFormats`. This is the single functional change: it gates both drag-drop and the file-dialog filter for spectral libraries.

That is the **only** code change. In practice `MetaDrawLogic.cs` and `MetaDrawDataLoader.cs` need no edits — they are format-agnostic: they hold the library paths and hand them to mzLib's `SpectralLibrary`, whose constructor already routes `.msl` files transparently (via `MslFileTypeHandler`). Nothing in MetaDraw's existing logic or behavior is altered.

### Test (additive)
- **`TestMetaDrawWithMslSpectralLibrary`** converts the existing `.msp` test libraries to `.msl` in-test (no new binary fixture committed), loads them through the unchanged MetaDrawLogic → MetaDrawDataLoader path, and asserts MetaDraw renders an **identical mirror plot (same 52 library peaks)** as the sibling `.msp` test `TestMetaDrawWithSpectralLibrary` — confirming lossless display.

Verified locally: `Passed! - Failed: 0, Passed: 1`.

Note: base branch is `feat/msl-spectral-library-input` (the #2674 head) so this stacks on it; retarget to `master` once #2674 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)